### PR TITLE
Added width curve property

### DIFF
--- a/addons/godot-polyliner/demos/demo/Spatial.tscn
+++ b/addons/godot-polyliner/demos/demo/Spatial.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=53 format=2]
 
 [ext_resource path="res://addons/godot-polyliner/demos/default_env.tres" type="Environment" id=1]
 [ext_resource path="res://addons/godot-polyliner/shaders/line_glow.gdshader" type="Shader" id=2]
 [ext_resource path="res://addons/godot-polyliner/Line3D/LinePath3D.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-polyliner/Trail3D/Trail3D.gd" type="Script" id=4]
-[ext_resource path="res://addons/godot-polyliner/shaders/swoosh.gdshader" type="Shader" id=5]
+[ext_resource path="res://addons/godot-polyliner/shaders/line_fade.gdshader" type="Shader" id=5]
 [ext_resource path="res://addons/godot-polyliner/shaders/parallax/raymarch_rope.gdshader" type="Shader" id=6]
 [ext_resource path="res://addons/godot-polyliner/Line3D/shaders/line_neon.shader" type="Shader" id=7]
 [ext_resource path="res://addons/godot-polyliner/shaders/line_pbr.gdshader" type="Shader" id=8]
@@ -52,7 +52,7 @@ _data = {
 
 [sub_resource type="ShaderMaterial" id=7]
 shader = ExtResource( 8 )
-shader_param/line_width = 0.03
+shader_param/line_width = 0.031
 shader_param/tangent_facing = false
 shader_param/rounded = false
 shader_param/uv_matches_width = true
@@ -71,13 +71,20 @@ _data = {
 "tilts": PoolRealArray( 0, 0 )
 }
 
+[sub_resource type="Curve" id=49]
+_data = [ Vector2( 0, 0 ), 0.0, 0.0, 0, 0, Vector2( 1, 0 ), -6.86684, -2.3, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=50]
+curve = SubResource( 49 )
+
 [sub_resource type="ShaderMaterial" id=9]
 shader = ExtResource( 5 )
-shader_param/line_width = 0.078
+shader_param/line_width = 0.177
 shader_param/tangent_facing = false
 shader_param/tangent_offset = 0.0
 shader_param/color = Color( 1, 0, 0, 1 )
-shader_param/alpha_curve = 0.145
+shader_param/alpha_curve = 0.5
+shader_param/width_curve = SubResource( 50 )
 
 [sub_resource type="Curve3D" id=10]
 bake_interval = 0.1
@@ -99,14 +106,21 @@ _data = {
 "tilts": PoolRealArray( 0, 0, 0, 0, 0, 0, 0 )
 }
 
+[sub_resource type="Curve" id=47]
+_data = [ Vector2( 0, 1 ), 0.519532, 0.0, 0, 0, Vector2( 1, 0 ), -3.0, 0.0, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=48]
+curve = SubResource( 47 )
+
 [sub_resource type="ShaderMaterial" id=33]
 shader = ExtResource( 2 )
-shader_param/tangent_facing = false
-shader_param/rounded = true
 shader_param/line_width = 0.0
 shader_param/glow_width = 0.4
+shader_param/tangent_facing = false
+shader_param/rounded = true
 shader_param/color = Color( 0, 0.396078, 0.956863, 1 )
 shader_param/curve = 0.2
+shader_param/width_curve = SubResource( 48 )
 
 [sub_resource type="Curve3D" id=12]
 bake_interval = 0.09
@@ -511,7 +525,7 @@ size = Vector3( 0.1, 0.1, 1.938 )
 [node name="Spatial" type="Spatial"]
 
 [node name="wormspinner" type="Spatial" parent="."]
-transform = Transform( -0.540772, 0, 0.84116, 0, 0.999999, 0, -0.841153, 0, -0.540777, -0.277619, 0.016, 3.531 )
+transform = Transform( 0.978218, 0, -0.207512, 0, 0.999999, 0, 0.207511, 0, 0.978228, 0.399602, 0.016, 3.531 )
 script = SubResource( 1 )
 mul = 1.59
 

--- a/addons/godot-polyliner/demos/ropetesting/ropetest.tscn
+++ b/addons/godot-polyliner/demos/ropetesting/ropetest.tscn
@@ -5,8 +5,9 @@
 [ext_resource path="res://addons/godot-polyliner/Line3D/LinePath3D.gd" type="Script" id=3]
 [ext_resource path="res://addons/godot-polyliner/Trail3D/Trail3D.gd" type="Script" id=4]
 [ext_resource path="res://addons/godot-polyliner/demos/ropetesting/ropetest.gd" type="Script" id=5]
-[ext_resource path="res://addons/godot-polyliner/shaders/swoosh.gdshader" type="Shader" id=6]
+[ext_resource path="res://addons/godot-polyliner/shaders/line_fade.gdshader" type="Shader" id=6]
 [ext_resource path="res://addons/godot-polyliner/shaders/parallax/raymarch_xmaslightbulbs.gdshader" type="Shader" id=7]
+
 
 [sub_resource type="ProceduralSky" id=1]
 sky_top_color = Color( 0.219608, 0.219608, 0.219608, 1 )

--- a/addons/godot-polyliner/shaders/line_fade.gdshader
+++ b/addons/godot-polyliner/shaders/line_fade.gdshader
@@ -8,6 +8,7 @@ render_mode unshaded;
 // with Tangent Facing enabled
 
 uniform float line_width = 0.4;
+uniform sampler2D width_curve : hint_albedo;
 uniform bool tangent_facing = true;
 uniform float tangent_offset = 0.5;
 float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
@@ -17,9 +18,10 @@ float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
 	if (!tangent_facing) {
 		perp = normalize(cross(dir_to_cam,dir_to_next_point));
 	}
-
+	
+	float curve_multiplier = texture(width_curve, uv).a;
 	float side = sign(float(uv.y > 0.5)-0.5);
-	vertex += (perp*side) * width;
+	vertex += (perp*side) * width * curve_multiplier;
 	
 	tangent = perp;
 	normal = cross(perp,dir_to_next_point);

--- a/addons/godot-polyliner/shaders/line_glow.gdshader
+++ b/addons/godot-polyliner/shaders/line_glow.gdshader
@@ -2,6 +2,9 @@ shader_type spatial;
 render_mode skip_vertex_transform, cull_disabled;
 render_mode blend_add, unshaded;
 
+uniform float line_width = 0.0;
+uniform float glow_width = 0.4;
+uniform sampler2D width_curve : hint_albedo;
 uniform bool tangent_facing = false;
 uniform bool rounded = true;
 float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
@@ -18,18 +21,15 @@ float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
 	if (rounded) { 
 		rounder = is_end * normalize(cross(perp,dir_to_cam));
 	}
-
+	float curve_multiplier = texture(width_curve, uv).a;
 	float side = sign(float(uv.y > 0.5)-0.5);
-	vertex += ((perp*side)-rounder) * width;
+	vertex += ((perp*side)-rounder) * width * curve_multiplier;
 	
 	tangent = perp;
 	normal = cross(perp,dir_to_next_point);
 	
 	return is_end;
 }
-
-uniform float line_width = 0.0;
-uniform float glow_width = 0.4;
 
 varying float is_end;
 varying float lw;

--- a/addons/godot-polyliner/shaders/line_pbr.gdshader
+++ b/addons/godot-polyliner/shaders/line_pbr.gdshader
@@ -3,6 +3,7 @@ render_mode skip_vertex_transform, cull_disabled;
 render_mode depth_draw_alpha_prepass;
 
 uniform float line_width = 0.1;
+uniform sampler2D width_curve : hint_albedo;
 uniform bool tangent_facing = false;
 uniform bool rounded = false;
 float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
@@ -19,9 +20,10 @@ float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
 	if (rounded) { 
 		rounder = is_end * normalize(cross(perp,dir_to_cam));
 	}
-
+	
+	float curve_multiplier = texture(width_curve, uv).a;
 	float side = sign(float(uv.y > 0.5)-0.5);
-	vertex += ((perp*side)-rounder) * width;
+	vertex += ((perp*side)-rounder) * width * curve_multiplier;
 	
 	tangent = perp;
 	normal = cross(perp,dir_to_next_point);

--- a/addons/godot-polyliner/shaders/line_pbr_vertexlit.gdshader
+++ b/addons/godot-polyliner/shaders/line_pbr_vertexlit.gdshader
@@ -4,6 +4,7 @@ render_mode vertex_lighting,specular_blinn;
 //render_mode depth_draw_alpha_prepass;
 
 uniform float line_width = 0.1;
+uniform sampler2D width_curve : hint_albedo;
 uniform bool tangent_facing = false;
 uniform bool rounded = false;
 float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
@@ -20,9 +21,10 @@ float line_process(float width, inout vec3 vertex, vec3 dir_to_cam, vec2 uv,
 	if (rounded) { 
 		rounder = is_end * normalize(cross(perp,dir_to_cam));
 	}
-
+	
+	float curve_multiplier = texture(width_curve, uv).a;
 	float side = sign(float(uv.y > 0.5)-0.5);
-	vertex += ((perp*side)-rounder) * width;
+	vertex += ((perp*side)-rounder) * width * curve_multiplier;
 	
 	tangent = perp;
 	normal = cross(perp,dir_to_next_point);


### PR DESCRIPTION
This PR adds an additional property to all the basic line shaders (`line_pbr`, `line_pbr_vertexlit`, `line_glow`, `line_fade`) since I needed that effect in one of my projects !
Additionally, I renamed the `swoosh` shader to `line_fade`, to make the name more explicit

![image](https://user-images.githubusercontent.com/39198556/201379402-111b11bd-d978-474c-86b3-d6c07ee79e51.png)

It's compatible with previous versions, so people updating the addon will not see any difference

Changes:
- added width_curve parameter in all basic line shaders
- updated demo scene to showcase the effect of width_curve
- renamed swoosh shader to line_fade
